### PR TITLE
English as source language

### DIFF
--- a/docs/deepl.md
+++ b/docs/deepl.md
@@ -23,8 +23,9 @@ zh : Chinese
 cs : Czech
 da : Danish
 nl : Dutch
-en-US : English (American)
-en-GB : English (British)
+en: English -Only for source language-
+en-US : English (American) -Only usable for destination language-
+en-GB : English (British) -Only usable for destination language-
 et : Estonian
 fi : Finnish
 fr : French

--- a/srtranslator/translators/deepl.py
+++ b/srtranslator/translators/deepl.py
@@ -25,8 +25,9 @@ class DeeplTranslator(Translator):
         "cs": "Czech",
         "da": "Danish",
         "nl": "Dutch",
-        "en-US": "English (American)",
-        "en-GB": "English (British)",
+        "en": "English",  # Only usable for source language
+        "en-US": "English (American)",  # Only usable for destination language
+        "en-GB": "English (British)",  # Only usable for destination language
         "et": "Estonian",
         "fi": "Finnish",
         "fr": "French",


### PR DESCRIPTION
Fix issue created when fixing #2. Now english as source language in DeeplTranslator is enabled again.