### PR TITLE
Update maximum character count in response to website update

### DIFF
--- a/srtranslator/translators/deepl_scrap.py
+++ b/srtranslator/translators/deepl_scrap.py
@@ -17,7 +17,7 @@ from .selenium_utils import (
 
 class DeeplTranslator(Translator):
     url = "https://www.deepl.com/translator"
-    max_char = 3000
+    max_char = 1500
     languages = {
         "auto": "Any language (detect)",
         "bg": "Bulgarian",


### PR DESCRIPTION
Today I noticed that the `DeeplTranslator` doesn't work anymore. After a bit of searching I've found out that the maximum character count on the DeepL website has been decreased to `1500`.

---

So all translations using `DeeplTranslator` now fail with the error `srtranslator.translators.base.TimeOutException: Translation timed out`.
This PR updates the maximum character count and fixes the mentioned problem.

---

I'd like to thank you for creating such a useful tool. I'm using it quite often and it really helps me :)